### PR TITLE
fixed persian translation file

### DIFF
--- a/language/fa/lng.conf
+++ b/language/fa/lng.conf
@@ -1,4 +1,4 @@
-﻿address = آدرس
+address = آدرس
 adduser = افزودن كاربر
 admin = مدیر
 all = همه


### PR DESCRIPTION
The translation file encoding was utf-8 with BOM and when somebody choose Persian translation
the screen goes blank. 
So I changed the file encoding and set it to utf-8 without BOM.