### PR TITLE
Mitigate XSS attack on user profile page

### DIFF
--- a/include/initfunctions.php
+++ b/include/initfunctions.php
@@ -207,6 +207,14 @@ function getArrayVal(array $array, $name)
     }
 }
 
+function purify($dirty)
+{
+    $config = HTMLPurifier_Config::createDefault();
+    $config->set('Cache.SerializerPath', CL_ROOT . "/files/standard/ics");
+    $purifier = new HTMLPurifier($config);
+    return $purifier->purify($dirty);
+}
+
 function cleanArray(array $theArray)
 {
     $outArray = array();

--- a/manageuser.php
+++ b/manageuser.php
@@ -208,6 +208,11 @@ if ($action == "loginerror") {
     $template->assign("title", $title);
     $template->assign("user", $profile);
 
+    // This is done specifically to address an XSS vulnerability
+    // caused by rendering two user inputs on same line in HTML.
+    // They must be escaped together and rendered as one.
+    $template->assign("zipcity", purify(implode(' ', [$profile['zip'], $profile['adress2']])));
+
     $template->display("userprofile.tpl");
 } elseif ($action == "showproject") {
     if (!chkproject($userid, $id)) {

--- a/templates/standard/userprofile.tpl
+++ b/templates/standard/userprofile.tpl
@@ -103,7 +103,7 @@
                                             <tbody class="color-b">
                                             <tr>
                                                 <td><strong>{#zip#} / {#city#}:</strong></td>
-                                                <td class="right">{$user.zip}{if $user.zip && $user.adress2} {/if}{$user.adress2} </td>
+                                                <td class="right">{$zipcity} </td>
                                             </tr>
                                             </tbody>
 


### PR DESCRIPTION
Came across this disclosure on Reddit today and figured I'd send some help while I had time.

See: https://devwerks.net/blog/16/how-not-to-use-html-purifier

Completely ignoring the snarky and passive aggressive title of their post, there was enough information in there to mitigate this specific attack. I am unfamiliar with this project so this may not be the "best way" to implement, but it does mitigate this attack while not impacting end-users at all, as far as I can tell.

If there are **any** other templates that output two variables in the same local space, they will need a similar treatment.

Hope all is well!

Screenie of output after mitigation:

![image](https://cloud.githubusercontent.com/assets/2453394/19468569/10825196-94e5-11e6-8d9a-9ec5daaaf9e4.png)
